### PR TITLE
Filter 'Running' phase in getNodeResourcePercent

### DIFF
--- a/client/src/utils/metricsHelpers.js
+++ b/client/src/utils/metricsHelpers.js
@@ -12,16 +12,17 @@ export default function getMetrics(items, metrics) {
 
 
 // Node helpers
-export function getNodeResourceValue(node, pods, resource, type) {
+export function getNodeResourceValue(node, pods, resource, type, phases) {
     if (!node || !pods) return null;
 
     return _(pods)
         .filter(x => x.spec.nodeName === node.metadata.name)
+        .filter(x => !phases || phases.indexOf(x.status.phase) >= 0)
         .sumBy(x => getPodResourceValue(x, resource, type));
 }
 
 export function getNodeResourcePercent(node, pods, resource, type) {
-    const used = getNodeResourceValue(node, pods, resource, type);
+    const used = getNodeResourceValue(node, pods, resource, type, ['Running']);
     const available = getNodeResourcesAvailable(node, resource);
     return used / available;
 }


### PR DESCRIPTION
<img width="373" alt="DeepinScreenshot_select-area_20200702153851" src="https://user-images.githubusercontent.com/1676756/86331870-43579000-bc7c-11ea-984f-70a50fbaae3c.png">

Both requests and limits may exceed 100% of the physical resources.