### PR TITLE
Filter 'Running' phase in getResourcePercentDisplay

### DIFF
--- a/client/src/components/nodesPanel.js
+++ b/client/src/components/nodesPanel.js
@@ -115,7 +115,7 @@ function getPercentDisplay(node, metrics, resource) {
 }
 
 function getResourcePercentDisplay(node, pods, resource, type) {
-    const used = getNodeResourceValue(node, pods, resource, type);
+    const used = getNodeResourceValue(node, pods, resource, type, ["Running"]);
     return percent(node, used, resource);
 }
 


### PR DESCRIPTION
I am very sorry that the previous fix is not complete. I missed the resource calculation in `getResourcePercentDisplay`.

Before this patch,
<img width="437" alt="DeepinScreenshot_select-area_20200710151135" src="https://user-images.githubusercontent.com/1676756/87127656-da49cb00-c2c0-11ea-92e4-47eb7b516607.png">

After this patch, the default view is like,
<img width="420" alt="DeepinScreenshot_select-area_20200710151151" src="https://user-images.githubusercontent.com/1676756/87127711-ef265e80-c2c0-11ea-9fe0-a8c6cfad62f4.png">

And the sorters are also correct.
<img width="426" alt="DeepinScreenshot_select-area_20200710151203" src="https://user-images.githubusercontent.com/1676756/87127742-02d1c500-c2c1-11ea-84f3-dfadc88d1ec2.png">
<img width="432" alt="DeepinScreenshot_select-area_20200710151219" src="https://user-images.githubusercontent.com/1676756/87127767-12510e00-c2c1-11ea-9c11-402e3650cd7b.png">

