### PR TITLE
gh-96: remove trailing slashes to enable relative links on dashboard event list

### DIFF
--- a/client/src/components/eventsPanel.tsx
+++ b/client/src/components/eventsPanel.tsx
@@ -76,24 +76,24 @@ function getName({kind, namespace, name} : InvolvedObject) {
 
 function getHref(kind: string, namespace: string, name: string) {
     switch (kind) {
-        case 'ClusterRole': return `/#!clusterrole/${name}`;
-        case 'ClusterRoleBinding': return `/#!clusterrolebinding/${name}`;
-        case 'ConfigMap': return `/#!configmap/${namespace}/${name}`;
-        case 'DaemonSet': return `/#!workload/daemonset/${namespace}/${name}`;
-        case 'Deployment': return `/#!workload/deployment/${namespace}/${name}`;
-        case 'Ingress': return `/#!ingress/${namespace}/${name}`;
-        case 'Node': return `/#!node/${name}`;
-        case 'PersistentVolume': return `/#!persistentvolume/${name}`;
-        case 'PersistentVolumeClaim': return `/#!persistentvolumeclaim/${namespace}/${name}`;
-        case 'Pod': return `/#!pod/${namespace}/${name}`;
-        case 'ReplicaSet': return `/#!replicaset/${namespace}/${name}`;
-        case 'Role': return `/#!role/${namespace}/${name}`;
-        case 'RoleBinding': return `/#!rolebinding/${namespace}/${name}`;
-        case 'Secret': return `/#!secret/${namespace}/${name}`;
-        case 'Service': return `/#!service/${namespace}/${name}`;
-        case 'ServiceAccount': return `/#!serviceaccount/${namespace}/${name}`;
-        case 'StatefulSet': return `/#!workload/statefulset/${namespace}/${name}`;
-        case 'StorageClass': return `/#!storageclass/${name}`;
+        case 'ClusterRole': return `#!clusterrole/${name}`;
+        case 'ClusterRoleBinding': return `#!clusterrolebinding/${name}`;
+        case 'ConfigMap': return `#!configmap/${namespace}/${name}`;
+        case 'DaemonSet': return `#!workload/daemonset/${namespace}/${name}`;
+        case 'Deployment': return `#!workload/deployment/${namespace}/${name}`;
+        case 'Ingress': return `#!ingress/${namespace}/${name}`;
+        case 'Node': return `#!node/${name}`;
+        case 'PersistentVolume': return `#!persistentvolume/${name}`;
+        case 'PersistentVolumeClaim': return `#!persistentvolumeclaim/${namespace}/${name}`;
+        case 'Pod': return `#!pod/${namespace}/${name}`;
+        case 'ReplicaSet': return `#!replicaset/${namespace}/${name}`;
+        case 'Role': return `#!role/${namespace}/${name}`;
+        case 'RoleBinding': return `#!rolebinding/${namespace}/${name}`;
+        case 'Secret': return `#!secret/${namespace}/${name}`;
+        case 'Service': return `#!service/${namespace}/${name}`;
+        case 'ServiceAccount': return `#!serviceaccount/${namespace}/${name}`;
+        case 'StatefulSet': return `#!workload/statefulset/${namespace}/${name}`;
+        case 'StorageClass': return `#!storageclass/${name}`;
         default: return undefined;
     }
 }


### PR DESCRIPTION
Fixes #96 

Verified that event list links work under the absolute and relative paths
![Screenshot from 2020-09-04 15-52-25](https://user-images.githubusercontent.com/9147304/92283953-ab1d9780-eec6-11ea-9b50-e92be343e148.png)
![Screenshot from 2020-09-04 15-46-07](https://user-images.githubusercontent.com/9147304/92283591-d358c680-eec5-11ea-8b60-795439707785.png)
