### PR TITLE
Remove comparing a string and a number

### DIFF
--- a/client/src/components/nodesPanel.tsx
+++ b/client/src/components/nodesPanel.tsx
@@ -151,7 +151,7 @@ function percent(node: Node, used: number | string | null, resource: ResourceTyp
     const result = unparser(used);
 
     const available = getNodeResourcesAvailable(node, resource);
-    const displayPercent = available ? _.round(Number(used) / available * 100, 1) : '';
+    const displayPercent = available ? _.round(Number(used) / available * 100, 1) : 0;
     const className = displayPercent >= 85 ? 'contentPanel_warn' : undefined;
 
     return (


### PR DESCRIPTION
Comparing [:155] a string [:154] (from string literal "" [:154] ) and a number [:155] (from number literal 85 [:155] ) might behave differently than you expect, as implicit conversion is performed. Replace `''` with `0` because we use it to display number near the percent sign.