### PR TITLE
feat(filter): allow permalinks after filtering for deeping-linking

### DIFF
--- a/client/src/components/filter.tsx
+++ b/client/src/components/filter.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useCallback } from 'react';
+import React, { Component } from 'react';
 import InputFilter from './inputFilter';
 import NamespaceFilter from './namespaceFilter';
 
@@ -9,42 +9,40 @@ type FilterProps = {
     onNamespaceChange?: (namespace: string) => void;
 }
 
-function handleFilterOnChange(cb: (value: string) => void) {
-    return (val: string) => {
-        if(val) {
-            const url = new URL(window.location.href)
-            url.searchParams.set('filterKey', val)
-            window.history.replaceState({url: url.href}, '', url.search + url.hash)
-        }        
-        return cb(val)
+function handleSaveOnBlur(value: string) {
+    if(value) {
+        const url = new URL(window.location.href)
+        url.searchParams.set('filterKey', value)
+        window.history.replaceState({url: url.href}, '', url.search + url.hash)
+    } else {
+        const url = new URL(window.location.href)
+        url.searchParams.delete('filterKey')
+        window.history.replaceState({url: url.href}, '', url.search + url.hash)
     }
 }
 
-function onInit(cb: (value: string) => void) {    
-    return () => {
+export default class Filter extends Component<FilterProps> {
+    componentDidMount() {
+        const { onChange } = this.props
         const urlParams = new URLSearchParams(window.location.search);    
-        const filterKey = urlParams.get('filterKey')
-        if (filterKey){
-            cb(filterKey)
-        }    
+        const filterKey = urlParams.get('filterKey') || ''
+        onChange(filterKey)
     }
-}
 
-const Filter = ({text, filter, onChange, onNamespaceChange}: FilterProps) => {
-    const memoedOnChange = useCallback(onChange, [])
+    render() {
+        const {text, filter, onChange, onNamespaceChange} = this.props
 
-    useEffect(onInit(memoedOnChange), [memoedOnChange])
+        return (
+            <div id='header'>
+                <span className='header_label'>{text}</span>
     
-    return (
-        <div id='header'>
-            <span className='header_label'>{text}</span>
-
-            {onNamespaceChange && (
-                <NamespaceFilter onChange={handleFilterOnChange(onNamespaceChange)} />
-            )}
-
-            <InputFilter filter={filter} onChange={handleFilterOnChange(onChange)} />
-        </div>
-    )
+                {onNamespaceChange && (
+                    <NamespaceFilter onChange={onNamespaceChange} />
+                )}
+    
+                <InputFilter filter={filter} onBlur={handleSaveOnBlur} onChange={onChange} />
+            </div>
+        )
+    }
+    
 }
-export default Filter;

--- a/client/src/components/filter.tsx
+++ b/client/src/components/filter.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useCallback } from 'react';
 import InputFilter from './inputFilter';
 import NamespaceFilter from './namespaceFilter';
 
@@ -9,16 +9,42 @@ type FilterProps = {
     onNamespaceChange?: (namespace: string) => void;
 }
 
-const Filter = ({text, filter, onChange, onNamespaceChange}: FilterProps) => (
-    <div id='header'>
-        <span className='header_label'>{text}</span>
+function handleFilterOnChange(cb: (value: string) => void) {
+    return (val: string) => {
+        if(val) {
+            const url = new URL(window.location.href)
+            url.searchParams.set('filterKey', val)
+            window.history.replaceState({url: url.href}, '', url.search + url.hash)
+        }        
+        return cb(val)
+    }
+}
 
-        {onNamespaceChange && (
-            <NamespaceFilter onChange={onNamespaceChange} />
-        )}
+function onInit(cb: (value: string) => void) {    
+    return () => {
+        const urlParams = new URLSearchParams(window.location.search);    
+        const filterKey = urlParams.get('filterKey')
+        if (filterKey){
+            cb(filterKey)
+        }    
+    }
+}
 
-        <InputFilter filter={filter} onChange={onChange} />
-    </div>
-);
+const Filter = ({text, filter, onChange, onNamespaceChange}: FilterProps) => {
+    const memoedOnChange = useCallback(onChange, [])
 
+    useEffect(onInit(memoedOnChange), [memoedOnChange])
+    
+    return (
+        <div id='header'>
+            <span className='header_label'>{text}</span>
+
+            {onNamespaceChange && (
+                <NamespaceFilter onChange={handleFilterOnChange(onNamespaceChange)} />
+            )}
+
+            <InputFilter filter={filter} onChange={handleFilterOnChange(onChange)} />
+        </div>
+    )
+}
 export default Filter;

--- a/client/src/components/inputFilter.tsx
+++ b/client/src/components/inputFilter.tsx
@@ -5,9 +5,10 @@ import Cancel from '../art/cancelSvg';
 type InputFilterProps = {
     filter: string;
     onChange: (value: string) => void;
+    onBlur: (value: string) => void;
 }
 
-const InputFilter = ({filter, onChange}: InputFilterProps) => (
+const InputFilter = ({filter, onChange, onBlur}: InputFilterProps) => (
     <>
         <input
             className='header_filter header_fill optional_xsmall'
@@ -15,6 +16,7 @@ const InputFilter = ({filter, onChange}: InputFilterProps) => (
             placeholder='type to filter'
             value={filter}
             onChange={x => onChange(x.target.value)}
+            onBlur={x => onBlur(x.target.value)}
             onKeyUp={(x) => {
                 // Clear the textbox on `esc` keypress
                 if (x.keyCode === 27) onChange('');
@@ -24,7 +26,7 @@ const InputFilter = ({filter, onChange}: InputFilterProps) => (
         {filter.length === 0 ? (
             <Search className='optional_xsmall' />
         ) : (
-            <Cancel className='svg_button svg_error optional_xsmall' onClick={() => onChange('')} />
+            <Cancel className='svg_button svg_error optional_xsmall' onClick={() => {onChange(''); onBlur('')}} />
         )}
     </>
 );

--- a/client/src/components/sorter.tsx
+++ b/client/src/components/sorter.tsx
@@ -70,14 +70,15 @@ export default class Sorter extends Base<SorterProps, SorterStates> {
     }
 
     componentDidMount() {
-        const {sort} = this.props;
+        const {sort, field} = this.props;
 
         const urlParams = new URLSearchParams(window.location.search);
         
         const sortKey = urlParams.get('sortKey')
         const sortDir = urlParams.get('sortDir')
 
-        if(sort && getFieldName(sort.field) === sortKey) {
+        if(sort && getFieldName(field) === sortKey) {
+            sort.field = field
             sort.direction = sortDir as Direction
             sort.onSort(sort)
         }

--- a/client/src/router.tsx
+++ b/client/src/router.tsx
@@ -121,6 +121,8 @@ registerRoute('workload/statefulset/:namespace/:name', params => <StatefulSet {.
 
 window.addEventListener('hashchange', onNavigate);
 
+window.onpopstate = onNavigate; // this is used by filter query params to handle back button clicks
+
 export function initRouter(cb: Handler) {
     handler = cb;
     onNavigate();

--- a/client/src/router.tsx
+++ b/client/src/router.tsx
@@ -121,7 +121,7 @@ registerRoute('workload/statefulset/:namespace/:name', params => <StatefulSet {.
 
 window.addEventListener('hashchange', onNavigate);
 
-window.onpopstate = onNavigate; // this is used by filter query params to handle back button clicks
+window.onpopstate = onNavigate; // this is used by filter/sort query params to handle back button clicks
 
 export function initRouter(cb: Handler) {
     handler = cb;

--- a/client/src/views/logs.tsx
+++ b/client/src/views/logs.tsx
@@ -5,7 +5,7 @@ import Switch from 'react-switch';
 import Select from 'react-select';
 import Ansi from 'ansi-to-react';
 import Base from '../components/base';
-import InputFilter from '../components/inputFilter';
+import Filter from '../components/filter';
 import Loading from '../components/loading';
 import api from '../services/api';
 import { Pod } from '../utils/types';
@@ -133,7 +133,8 @@ export default class Logs extends Base<Props, State> {
                         <div className='logs_showPreviousLabel'>Previous</div>
                     </label>
 
-                    <InputFilter
+                    <Filter
+                        text='Pods'
                         filter={filter}
                         onChange={x => this.setState({filter: x})}
                     />


### PR DESCRIPTION
Altered filter.tsx to allow altering the query-param on change.

In router.tsx I added the `onpopstate` function to handle back-buttons after filters where made.

for filter.tsx I opted for using the `window.history.replaceState` instead of the `window.history.pushState`, as pushState would have made the back-button go back to each letter as it was typed in the filter field.  Because I opted for the replaceState, I needed to add the `onpopstate` function to correctly handle back-button clicks again.

fix #153 