### PR TITLE
pod exec view typo

### DIFF
--- a/client/src/views/exec.tsx
+++ b/client/src/views/exec.tsx
@@ -96,7 +96,7 @@ export default class Exec extends Base<Props, State> {
         return (
             <div id='content'>
                 <div id='header'>
-                    <span className='header_label'>{['Pod Logs', namespace, name].join(' • ')}</span>
+                    <span className='header_label'>{['Pod Exec', namespace, name].join(' • ')}</span>
 
                     <div className='select_namespace'>
                         <Select


### PR DESCRIPTION
Noticed a typo in the header when using the dashboard today, quick fix
