### PR TITLE
Issue 166 fixed by changing version of the imported yaml node module

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -8473,7 +8473,7 @@
         },
         "tough-cookie": {
           "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+          "resolved": "https://nexus.corp.indeed.com/repository/npm/tough-cookie/-/tough-cookie-2.5.0.tgz",
           "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
           "requires": {
             "psl": "^1.1.28",
@@ -16358,9 +16358,9 @@
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     },
     "yaml": {
-      "version": "2.0.0-1",
-      "resolved": "https://nexus.corp.indeed.com/repository/npm/yaml/-/yaml-2.0.0-1.tgz",
-      "integrity": "sha512-W7h5dEhywMKenDJh2iX/LABkbFnBxasD27oyXWDS/feDsxiw0dD5ncXdYXgkvAsXIY2MpW/ZKkr9IU30DBdMNQ=="
+      "version": "1.10.0",
+      "resolved": "https://nexus.corp.indeed.com/repository/npm/yaml/-/yaml-1.10.0.tgz",
+      "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg=="
     },
     "yargs": {
       "version": "13.3.2",

--- a/client/package.json
+++ b/client/package.json
@@ -28,7 +28,7 @@
     "swagger-parser": "^7.0.1",
     "typescript": "^4.0.3",
     "xterm": "^3.14.5",
-    "yaml": "^2.0.0-0"
+    "yaml": "^1.10.0"
   },
   "scripts": {
     "start": "cross-env react-scripts start",


### PR DESCRIPTION
Fixed issue https://github.com/indeedeng/k8dash/issues/166 by updating the imported yaml version to 1.10.0, instead of 2.0.0.  The bug was introduced by the MR for issue https://github.com/indeedeng/k8dash/pull/149 does fix the newline problem, only the version being imported wasn't correct.

Note the newlines shown in the annotation are expected, as those are part of the actual yaml spec.

Before the new yaml package, the spec had two unexpected formatting issues
- the data section had newlines visible as \n
- the annotation section had the newlines escaped
```
kind: ConfigMap
apiVersion: v1
metadata:
  name: coredns
  namespace: kube-system
  selfLink: /api/v1/namespaces/kube-system/configmaps/coredns
  uid: 9f4c55de-3f22-494c-898a-e0e67423e601
  resourceVersion: '297'
  creationTimestamp: '2020-10-13T20:57:39Z'
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: "{\"apiVersion\":\"v1\",\"data\":{\"Corefile\":\".:53 {\\n    log\\n    whoami\\n    errors\\n    health\\n    hosts {\\n      10.40.40.100 admin\\n      fallthrough\\n    }\\n    kubernetes cluster.local in-addr.arpa ip6.arpa {\\n       pods insecure\\n       upstream\\n       fallthrough in-addr.arpa ip6.arpa\\n    }\\n    prometheus :9153\\n    forward . /etc/resolv.conf\\n    cache 30\\n    loop\\n    reload\\n    loadbalance\\n}\\n\"},\"kind\":\"ConfigMap\",\"metadata\":{\"annotations\":{},\"name\":\"coredns\",\"namespace\":\"kube-system\"}}\n"
data:
  Corefile: ".:53 {\n    log\n    whoami\n    errors\n    health\n    hosts {\n      10.40.40.100 admin\n      fallthrough\n    }\n    kubernetes cluster.local in-addr.arpa ip6.arpa {\n       pods insecure\n       upstream\n       fallthrough in-addr.arpa ip6.arpa\n    }\n    prometheus :9153\n    forward . /etc/resolv.conf\n    cache 30\n    loop\n    reload\n    loadbalance\n}\n"
```

After the addition of the new yaml package, the annotation section and data section match what kubectl -o yaml would provide
```
kind: ConfigMap
apiVersion: v1
metadata:
  name: coredns
  namespace: kube-system
  selfLink: /api/v1/namespaces/kube-system/configmaps/coredns
  uid: 9f4c55de-3f22-494c-898a-e0e67423e601
  resourceVersion: "297"
  creationTimestamp: 2020-10-13T20:57:39Z
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: >
      {"apiVersion":"v1","data":{"Corefile":".:53
      {\n    log\n    whoami\n    errors\n    health\n    hosts
      {\n      10.40.40.100 admin\n      fallthrough\n    }\n    kubernetes
      cluster.local in-addr.arpa ip6.arpa {\n       pods
      insecure\n       upstream\n       fallthrough in-addr.arpa
      ip6.arpa\n    }\n    prometheus :9153\n    forward .
      /etc/resolv.conf\n    cache
      30\n    loop\n    reload\n    loadbalance\n}\n"},"kind":"ConfigMap","metadata":{"annotations":{},"name":"coredns","namespace":"kube-system"}}
data:
  Corefile: |
    .:53 {
        log
        whoami
        errors
        health
        hosts {
          10.40.40.100 admin
          fallthrough
        }
        kubernetes cluster.local in-addr.arpa ip6.arpa {
           pods insecure
           upstream
           fallthrough in-addr.arpa ip6.arpa
        }
        prometheus :9153
        forward . /etc/resolv.conf
        cache 30
        loop
        reload
        loadbalance
    }
```