### PR TITLE
Points all URLs to indeedeng

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ k8dash is the easiest way to manage your Kubernetes cluster. Why?
 
 
 ## Click the video below to see k8dash in action
-[![k8dash - Kubernetes Dashboard](https://raw.githubusercontent.com/herbrandson/k8dash/master/docs/videoThumbnail.png)](http://www.youtube.com/watch?v=u-1jGAhAHAM "k8dash - Kubernetes Dashboard")
+[![k8dash - Kubernetes Dashboard](https://raw.githubusercontent.com/indeedeng/k8dash/master/docs/videoThumbnail.png)](http://www.youtube.com/watch?v=u-1jGAhAHAM "k8dash - Kubernetes Dashboard")
 
 <br>
 
@@ -46,10 +46,10 @@ Back to [Table of Contents](#table_of_contents)
 ## Getting Started
 Deploy k8dash with something like the following...
 
-NOTE: never trust a file downloaded from the internet. Make sure to review the contents of [kubernetes-k8dash.yaml](https://raw.githubusercontent.com/herbrandson/k8dash/master/kubernetes-k8dash.yaml) before running the script below.
+NOTE: never trust a file downloaded from the internet. Make sure to review the contents of [kubernetes-k8dash.yaml](https://raw.githubusercontent.com/indeedeng/k8dash/master/kubernetes-k8dash.yaml) before running the script below.
 
 ``` bash
-kubectl apply -f https://raw.githubusercontent.com/herbrandson/k8dash/master/kubernetes-k8dash.yaml
+kubectl apply -f https://raw.githubusercontent.com/indeedeng/k8dash/master/kubernetes-k8dash.yaml
 ```
 
 To access k8dash, you must make it publicly visible. If you have an ingress server setup, you can accomplish by adding a route like the following
@@ -113,7 +113,7 @@ back to [Table of Contents](#table_of_contents)
 
 <a name="oidc"></a>
 ## Running k8dash with OpenId Connect (oidc)
-k8dash makes using OpenId Connect for authentication easy. Assuming your cluster is configured to use OIDC, all you need to do is create a secret containing your credentials and run the [kubernetes-k8dash-oidc.yaml](https://raw.githubusercontent.com/herbrandson/k8dash/master/kubernetes-k8dash-oidc.yaml) config.
+k8dash makes using OpenId Connect for authentication easy. Assuming your cluster is configured to use OIDC, all you need to do is create a secret containing your credentials and run the [kubernetes-k8dash-oidc.yaml](https://raw.githubusercontent.com/indeedeng/k8dash/master/kubernetes-k8dash-oidc.yaml) config.
 
 To learn more about configuring a cluster for OIDC, check out these great links
 + [https://kubernetes.io/docs/reference/access-authn-authz/authentication/](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#openid-connect-tokens)
@@ -123,7 +123,7 @@ To learn more about configuring a cluster for OIDC, check out these great links
 
 You can deploy k8dash with oidc support using something like the following script...
 
-NOTE: never trust a file downloaded from the internet. Make sure to review the contents of [kubernetes-k8dash-oidc.yaml](https://raw.githubusercontent.com/herbrandson/k8dash/master/kubernetes-k8dash-oidc.yaml) before running the script below.
+NOTE: never trust a file downloaded from the internet. Make sure to review the contents of [kubernetes-k8dash-oidc.yaml](https://raw.githubusercontent.com/indeedeng/k8dash/master/kubernetes-k8dash-oidc.yaml) before running the script below.
 
 ``` bash
 OIDC_URL=<put your endpoint url here... something like https://accounts.google.com>
@@ -135,7 +135,7 @@ kubectl create secret -n kube-system generic k8dash \
 --from-literal=id="$OIDC_ID" \
 --from-literal=secret="$OIDC_SECRET"
 
-kubectl apply -f https://raw.githubusercontent.com/herbrandson/k8dash/master/kubernetes-k8dash-oidc.yaml
+kubectl apply -f https://raw.githubusercontent.com/indeedeng/k8dash/master/kubernetes-k8dash-oidc.yaml
 
 ```
 
@@ -147,7 +147,7 @@ Back to [Table of Contents](#table_of_contents)
 
 <a name="Nodeport"></a>
 ## Running k8dash with NodePort
-If you do not have an ingress server setup, you can utilize a NodePort service as configured in the [kubernetes-k8dash-nodeport.yaml](https://raw.githubusercontent.com/herbrandson/k8dash/master/kubernetes-k8dash-nodeport.yaml). This is ideal when creating a single node master, or if you want to get up and running as fast as possible.
+If you do not have an ingress server setup, you can utilize a NodePort service as configured in the [kubernetes-k8dash-nodeport.yaml](https://raw.githubusercontent.com/indeedeng/k8dash/master/kubernetes-k8dash-nodeport.yaml). This is ideal when creating a single node master, or if you want to get up and running as fast as possible.
 
 This will map the k8dash port 4654 to a randomly selected port on the running node. The assigned port can be found using
 ```
@@ -204,7 +204,7 @@ Back to [Table of Contents](#table_of_contents)
 <a name="License"></a>
 # License
 
-[Apache License 2.0](https://raw.githubusercontent.com/herbrandson/k8dash/master/LICENSE)
+[Apache License 2.0](https://raw.githubusercontent.com/indeedeng/k8dash/master/LICENSE)
 
 
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Findeedeng%2Fk8dash.svg?type=large)](https://app.fossa.com/projects/git%2Bgithub.com%2Findeedeng%2Fk8dash?ref=badge_large)


### PR DESCRIPTION
The README was written before it was published as indeedeng, and some of the URLs pointed to a personal user's account rather than indeedeng.