### PR TITLE
Add protobuf support for metric kind PodList #191

### DIFF
--- a/client/src/utils/protoHelpers.ts
+++ b/client/src/utils/protoHelpers.ts
@@ -7,10 +7,17 @@ const {PodMetrics} = k8s.io.metrics.pkg.apis.metrics.v1beta1;
 const {PodMetricsList} = k8s.io.metrics.pkg.apis.metrics.v1beta1;
 const {EventList} = k8s.io.api.core.v1;
 const {NodeList} = k8s.io.api.core.v1;
+const {PodList} = k8s.io.api.core.v1;
 
 export const kindMap: {
         [index: string]: {
-            proto: typeof NodeMetrics | typeof NodeMetricsList | typeof PodMetrics | typeof PodMetricsList | typeof EventList | typeof NodeList,
+            proto: typeof NodeMetrics
+                | typeof NodeMetricsList
+                | typeof PodMetrics
+                | typeof PodMetricsList
+                | typeof EventList
+                | typeof NodeList
+                | typeof PodList,
             path: string
         }
     } = {
@@ -37,6 +44,10 @@ export const kindMap: {
         NodeList: {
             proto: NodeList,
             path: 'api/v1/nodes',
+        },
+        PodList: {
+            proto: PodList,
+            path: 'api/v1/pods',
         },
     };
 


### PR DESCRIPTION
Proto enabled:
<img width="317" alt="proto" src="https://user-images.githubusercontent.com/5899852/107847149-521a3e00-6e2c-11eb-9d74-3162a3b9438a.png">

Proto disabled:
<img width="340" alt="json" src="https://user-images.githubusercontent.com/5899852/107847145-4f1f4d80-6e2c-11eb-9cf7-fb297d7e7138.png">
