### PR TITLE
Update Dockerfile for ARM build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@
 FROM node:12.4.0-alpine as build-deps
 WORKDIR /usr/src/app
 COPY client/package.json client/package-lock.json ./
+RUN apk add --no-cache python build-base
 RUN npm i
 
 COPY client/ ./


### PR DESCRIPTION
Update Dockerfile for ARM build
Adding these simple packages to Alpine allows to build k8dash on ARM machines. 
Container image was successfully built and deployed on a K8S cluster based on Raspberry Pi 4. 
