### PR TITLE
244: Update replica cpu and memory usage

### DIFF
--- a/client/src/components/podCpuChart.tsx
+++ b/client/src/components/podCpuChart.tsx
@@ -3,15 +3,14 @@ import React from 'react';
 // import Chart from './chart';
 import LoadingChart from './loadingChart';
 import {parseCpu, TO_ONE_CPU} from '../utils/unitHelpers';
-import {Pod, Metrics} from '../utils/types';
+import {Pod, Metrics, ReplicaSet} from '../utils/types';
 import PrometheusGraph from '../views/prometheusgraph';
 
-export default function PodCpuChart({items, metrics, pod}: {items?: Pod[], metrics?: _.Dictionary<Metrics>, pod?: Pod}) {
+export default function PodCpuChart({items, metrics, item}: {items?: Pod[], metrics?: _.Dictionary<Metrics>, item?: Pod | ReplicaSet}) {
     const totals = getPodCpuTotals(items, metrics);
     // const decimals = totals && totals.used > 10 ? 1 : 2;
-
     const defaultLabels = "unit='core', resource='cpu'";
-    const labelMatchers = pod ? `${defaultLabels}, pod="${pod.metadata.name}"` : defaultLabels;
+    const labelMatchers = item ? `${defaultLabels}, pod="${item.metadata.name}"` : defaultLabels;
 
     const query = {
         queryString: `sum(kube_pod_container_resource_requests{${labelMatchers}})`,
@@ -45,7 +44,6 @@ export default function PodCpuChart({items, metrics, pod}: {items?: Pod[], metri
 
 function getPodCpuTotals(pods?: Pod[], metrics?: _.Dictionary<Metrics>) {
     if (!pods || !metrics) return null;
-
     const used = _(metrics)
         .flatMap(x => x.containers)
         .sumBy(x => parseCpu(x.usage.cpu));

--- a/client/src/components/podRamChart.tsx
+++ b/client/src/components/podRamChart.tsx
@@ -2,14 +2,14 @@ import _ from 'lodash';
 import React from 'react';
 import LoadingChart from './loadingChart';
 import {parseRam, TO_GB} from '../utils/unitHelpers';
-import {Pod, Metrics} from '../utils/types';
+import {Pod, Metrics, ReplicaSet} from '../utils/types';
 import PrometheusGraph from '../views/prometheusgraph';
 
-export default function RamChart({items, metrics, pod}: {items?: Pod[], metrics?: _.Dictionary<Metrics>, pod?: Pod}) {
+export default function RamChart({items, metrics, item}: {items?: Pod[], metrics?: _.Dictionary<Metrics>, item?: Pod | ReplicaSet}) {
     const totals = getPodRamTotals(items, metrics);
 
     const defaultLabels = "unit='byte'";
-    const labelMatchers = pod ? `${defaultLabels}, pod="${pod.metadata.name}"` : defaultLabels;
+    const labelMatchers = item ? `${defaultLabels}, pod="${item.metadata.name}"` : defaultLabels;
 
     const query = {
         queryString: `sum(kube_pod_container_resource_requests{${labelMatchers}}/${TO_GB})`,

--- a/client/src/views/pod.tsx
+++ b/client/src/views/pod.tsx
@@ -82,8 +82,8 @@ export default class PodView extends Base<Props, State> {
                 {errors && !!errors.length && <Error messages={errors} />}
 
                 <ChartsContainer>
-                    <PodCpuChart items={item && [item]} metrics={filteredMetrics} pod={item}/>
-                    <PodRamChart items={item && [item]} metrics={filteredMetrics} pod={item}/>
+                    <PodCpuChart items={item && [item]} metrics={filteredMetrics} item={item}/>
+                    <PodRamChart items={item && [item]} metrics={filteredMetrics} item={item}/>
                 </ChartsContainer>
 
                 <div className='contentPanel'>

--- a/client/src/views/replicaSet.tsx
+++ b/client/src/views/replicaSet.tsx
@@ -87,8 +87,8 @@ export default class ReplicaSetView extends Base<Props, State> {
 
                 <ChartsContainer>
                     <ReplicasChart item={item} />
-                    <PodCpuChart items={filteredPods} metrics={filteredMetrics} />
-                    <PodRamChart items={filteredPods} metrics={filteredMetrics} />
+                    <PodCpuChart items={filteredPods} metrics={filteredMetrics} item={item}/>
+                    <PodRamChart items={filteredPods} metrics={filteredMetrics} item={item}/>
                 </ChartsContainer>
 
                 <div className='contentPanel'>


### PR DESCRIPTION
Doesn't seem like there is a query that exists that successfully pulls cpu / memory usage based on replica set name.