### PR TITLE
batch/v1beta1 is removed since k8s-1.25

### DIFF
--- a/client/src/services/api.ts
+++ b/client/src/services/api.ts
@@ -29,7 +29,7 @@ const replicaSet = apiFactoryWithNamespace('apps', 'v1', 'replicasets', true);
 const statefulSet = apiFactoryWithNamespace('apps', 'v1', 'statefulsets', true);
 const hpa = apiFactoryWithNamespace('autoscaling', 'v1', 'horizontalpodautoscalers', true);
 
-const cronJob = apiFactoryWithNamespace('batch', 'v1beta1', 'cronjobs');
+const cronJob = apiFactoryWithNamespace('batch', 'v1', 'cronjobs');
 const job = apiFactoryWithNamespace('batch', 'v1', 'jobs');
 
 const ingress = apiFactoryWithNamespace('networking.k8s.io', 'v1', 'ingresses');


### PR DESCRIPTION
The Beta API version (batch/v1beta1) of CronJob is no longer served as of version 1.25. This API was deprecated in version 1.21

https://cloud.google.com/kubernetes-engine/docs/deprecations/apis-1-25