### PR TITLE
Support OIDC providers that return 'iss' in authorization response

### DIFF
--- a/client/src/services/api.ts
+++ b/client/src/services/api.ts
@@ -119,7 +119,7 @@ function metricsFactory() {
 function oidcFactory() {
     return {
         get: () => request('/oidc'),
-        post: (code: string, redirectUri: string) => post('/oidc', {code, redirectUri}),
+        post: (code: string, redirectUri: string, iss: string | null) => post('/oidc', {code, redirectUri, iss}),
     };
 }
 

--- a/client/src/views/auth.tsx
+++ b/client/src/views/auth.tsx
@@ -26,9 +26,10 @@ export default class Auth extends Base<{}, State> {
         const url = new URL(window.location.href);
         const code = url.searchParams.get('code');
         const state = url.searchParams.get('state');
+        const iss = url.searchParams.get('iss');
 
         if (code && state) {
-            this.oidcLogin(code, state);
+            this.oidcLogin(code, state, iss);
             return;
         }
 
@@ -68,7 +69,7 @@ export default class Auth extends Base<{}, State> {
         );
     }
 
-    async oidcLogin(code: string, returnedState: string) {
+    async oidcLogin(code: string, returnedState: string, iss: string | null) {
         const {state, redirectUri} = JSON.parse(sessionStorage.oidc) || {};
         delete sessionStorage.oidc;
 
@@ -80,7 +81,7 @@ export default class Auth extends Base<{}, State> {
         }
 
         try {
-            const {token} = await api.oidc.post(code, redirectUri);
+            const {token} = await api.oidc.post(code, redirectUri, iss);
             login(token, state);
         } catch (err) {
             log.error('OIDC login failed', {err});

--- a/server/index.js
+++ b/server/index.js
@@ -151,8 +151,8 @@ async function getOidc(req, res, next) {
 async function postOidc(req, res, next) {
     try {
         const body = await toString(req);
-        const {code, redirectUri} = JSON.parse(body);
-        const token = await oidcAuthenticate(code, redirectUri);
+        const {code, redirectUri, iss} = JSON.parse(body);
+        const token = await oidcAuthenticate(code, redirectUri, iss);
         res.json({token});
     } catch (err) {
         next(err);
@@ -208,7 +208,7 @@ async function getOidcEndpoint() {
     return provider.authorizationUrl(authParams);
 }
 
-async function oidcAuthenticate(code, redirectUri) {
+async function oidcAuthenticate(code, redirectUri, iss) {
     const provider = await getOidcProvider();
     let authCheckParams = {}
     if (OIDC_USE_PKCE) {
@@ -217,7 +217,9 @@ async function oidcAuthenticate(code, redirectUri) {
             code_verifier: codeVerifier
         }
     }
-    const tokenSet = await provider.callback(redirectUri, {code}, authCheckParams);
+    const tokenSet = iss != null ?
+        await provider.callback(redirectUri, {code, iss}, authCheckParams) :
+        await provider.callback(redirectUri, {code}, authCheckParams);
  
     if ( OIDC_USE_ACCESS_TOKEN ) {
         return tokenSet.access_token;


### PR DESCRIPTION
If the authorization provider returns an `iss` field in the authorization response, it should be passed into the POST to `/oidc` and then into the `openid-client` callback.  Fixes issue #441.

If `iss` is not in the authorization response, it still is sent to the `/oidc` endpoint but with its value null.  If this should be filtered out of the payload on the client side, I will revise the commit.